### PR TITLE
Add clarification about the sale in the README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # 👋 Hey there! Welcome to Fossify!
 
-Fossify is all about community-backed, open-source, and ad-free mobile apps. A fork of the @SimpleMobileTools, which is no longer maintained, and we're here to continue the legacy, bringing simple and private tech to everyone.
+Fossify is all about community-backed, open-source, and ad-free mobile apps. A fork of the @SimpleMobileTools, which is [no longer maintained](https://github.com/SimpleMobileTools/General-Discussion/issues/241), and we're here to continue the legacy, bringing simple and private tech to everyone.
 
 For general issues affecting the entire project, check out [general issues](https://github.com/FossifyOrg/General-Discussion/issues). Engage in discussions about various aspects of the project at [general discussions](https://github.com/FossifyOrg/General-Discussion/discussions).
 


### PR DESCRIPTION
When I discovered Fossify Gallery on F-Droid I saw it was a fork of Simple Gallery Pro and wondered what it changed. I wasn’t aware the latter had been sold. This is not written on the project’s page, and there is only a brief mention here that it is “no longer maintained”. Thus I went on their GitHub and website, and of course it didn’t mention it anywhere. Finally I searched Google, found their subreddit, browsed the posts and found the one related to the issue I linked in the README.

I think it deserves more clarification so that current Simple Apps users know why not to use these apps anymore and why this fork was created. I also suggest mentioning it in the projects’ descriptions as well. This would save current Simple Apps users a bit of time.