### PR TITLE
Add reusable workflows and workflow templates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,79 @@
+name: PR
+
+on:
+    workflow_call:
+        inputs:
+            run_lint:
+                description: 'Whether to run Android lint as a part of this workflow. True by default.'
+                type: boolean
+                default: true
+                required: false
+            run_detekt:
+                description: 'Whether to run detekt lint as a part of this workflow. True by default.'
+                type: boolean
+                default: true
+                required: false
+            run_tests:
+                description: 'Whether to run tests as a part of this workflow. True by default.'
+                type: boolean
+                default: true
+                required: false
+            test_task:
+                description: 'Tests gradle task to run. ":app:testCoreDebugUnitTest" by default'
+                type: string
+                default: ':app:testCoreDebugUnitTest'
+                required: false
+
+jobs:
+    android-lint:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.run_lint }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-java@v4
+              with:
+                  java-version: 17
+                  distribution: 'temurin'
+            - name: Run Android lint
+              id: lint
+              run: ./gradlew lint
+            - name: Update baseline
+              if: ${{ failure() && steps.lint.conclusion == 'failure' }}
+              run: ./gradlew updateLintBaseline
+            - name: Upload new baseline
+              uses: actions/upload-artifact@v4
+              if: ${{ failure() && steps.lint.conclusion == 'failure' }}
+              with:
+                  name: 'new-lint-baseline'
+                  path: 'app/lint-baseline.xml'
+            - name: Upload results
+              uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: 'lint-results'
+                  path: 'app/build/intermediates/lint_intermediate_text_report/coreDebug/lint-results-coreDebug.txt'
+
+
+    detekt:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.run_detekt }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-java@v4
+              with:
+                  java-version: 17
+                  distribution: 'temurin'
+            - name: Run detekt checks
+              run: ./gradlew detekt
+
+    test:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.run_tests }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-java@v4
+              with:
+                  java-version: 17
+                  distribution: 'temurin'
+            - name: Run tests
+              run: ./gradlew ${{ inputs.test_task }}

--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -1,0 +1,34 @@
+name: Testing build (on PR)
+
+on:
+    workflow_call:
+        inputs:
+            build_task:
+                description: 'Gradle task to run to build APK. "assemblePrepaidDebug" by default'
+                type: string
+                default: 'assemblePrepaidDebug'
+                required: false
+            expected_label:
+                description: 'Label to look for to run the build. "testers needed" by default'
+                type: string
+                default: 'testers needed'
+                required: false
+
+jobs:
+    testing_build:
+        runs-on: ubuntu-latest
+        if: contains(github.event.pull_request.labels.*.name, inputs.expected_label)
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-java@v4
+              with:
+                  java-version: 17
+                  distribution: 'temurin'
+            - name: Build debug APK
+              run: ./gradlew ${{ inputs.build_task }}
+            - name: Upload APK
+              id: upload
+              uses: actions/upload-artifact@v4
+              with:
+                  name: 'test-build'
+                  path: 'app/build/outputs/apk/**/*.apk'

--- a/workflow-templates/pr.properties.json
+++ b/workflow-templates/pr.properties.json
@@ -1,0 +1,5 @@
+{
+	"name": "Pull request workflow",
+	"description": "Pull request workflow for linters and tests.",
+	"iconName": "octicon git-pull-request"
+}

--- a/workflow-templates/pr.yml
+++ b/workflow-templates/pr.yml
@@ -1,0 +1,15 @@
+name: PR
+
+on:
+    pull_request:
+        branches: [ $default-branch ]
+
+jobs:
+    call-pr-workflow:
+        uses: FossifyOrg/.github/.github/workflows/pr.yml@main
+        # The following keys can be used to change defaults
+        # with:
+        #     run_lint: true
+        #     run_detekt: true
+        #     run_tests: true
+        #     test_task: ":app:testCoreDebugUnitTest"

--- a/workflow-templates/testing-build.properties.json
+++ b/workflow-templates/testing-build.properties.json
@@ -1,0 +1,5 @@
+{
+	"name": "Testing build workflow",
+	"description": "Workflow for creating testing builds for labeled PRs",
+	"iconName": "octicon beaker"
+}

--- a/workflow-templates/testing-build.yml
+++ b/workflow-templates/testing-build.yml
@@ -1,0 +1,14 @@
+name: Testing build (on PR)
+
+on:
+    pull_request:
+        branches: [ $default-branch ]
+        types: [ labeled, opened, synchronize, reopened ]
+
+jobs:
+    call-testing-build-workflow:
+        uses: FossifyOrg/.github/.github/workflows/testing-build.yml@main
+        # The following keys can be used to change defaults
+        # with:
+        #     build_task: 'aseemblePrepaidDebug'
+        #     expected_label: 'testers needed'


### PR DESCRIPTION
Adds reusable workflows based on https://github.com/FossifyOrg/Launcher/pull/12
Also adds workflow templates that demonstrate how to reuse that workflow. This will also enable quickly adding these workflows using GitHub (even though in this case, it will require a bit more setup for Android lint and detekt, similar to that Launcher PR).