### PR TITLE
Create FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: FossifyOrg
+patreon: # Replace with a single Patreon username e.g., user1
+open_collective: # Replace with a single Open Collective username e.g., user1
+ko_fi: # Replace with a single Ko-fi username e.g., user1
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+polar: # Replace with a single Polar username e.g., user1
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username e.g., user1
+thanks_dev: # Replace with a single thanks.dev username e.g., u/gh/user1
+community_bridge: fossify
+liberapay: naveensingh
+issuehunt: # Replace with a single IssueHunt username e.g., user1
+otechie: # Replace with a single Otechie username e.g., user1
+custom: ['https://www.fossify.org/donate/', 'https://www.patreon.com/naveen3singh', 'https://paypal.me/naveen3singh']


### PR DESCRIPTION
Hi,

This small PR adds a FUNDING.yml to this .github repo. This will be used to display a "Support" button inside all your repos, at the top of the page, but managed in just one place here.

It also allows you to have the control over the donation links shown by F-Droid website. For example, if you later want to add another link, or change the donate link, you can do it by yourself by adjusting this file in your own repo, without having to open a MR on F-Droid side to add the information in the [metadata file](https://gitlab.com/fdroid/fdroiddata). This reduce the load on the F-Droid repos and Teams, and give back the power to the developer.

Please note that GitHub doesn't want to add support for cryptos for now, so we still have to host this kind of information in our metadata files (you can't put your bitcoin adress in the FUNDING.yml file)...

Please ask me if you have any question regarding this subject.

(more information on FUNDING.yml files and GitHub Sponsors program [here](https://gist.github.com/Poussinou/c253ff56559ab42d08a46de1688a0fe8))