### PR TITLE
ci: auto label `ci` and `documentation` PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -28,3 +28,17 @@ jobs:
         with:
           github_token: ${{ secrets.FOSSIFYBOT_TOKEN }}
           labels: i18n
+
+      - name: Label CI PRs
+        if: contains(github.event.pull_request.title, 'ci')
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8
+        with:
+          github_token: ${{ secrets.FOSSIFYBOT_TOKEN }}
+          labels: ci
+
+      - name: Label Documentation PRs
+        if: contains(github.event.pull_request.title, 'docs')
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8
+        with:
+          github_token: ${{ secrets.FOSSIFYBOT_TOKEN }}
+          labels: documentation


### PR DESCRIPTION
This also relies on the existence of `docs` or `ci` in the PR title.