### PR TITLE
ci(commenter): ignore issues or pull requests with `released` label

### DIFF
--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.FOSSIFYBOT_TOKEN }}
           label-template: "released"
-          skip-label: "ci,dependencies,documentation,l10n,i18n"
+          skip-label: "ci,dependencies,documentation,l10n,i18n,released"
           comment-template: |
             FYI: This is available in {release_link}. FossifyBot out.


### PR DESCRIPTION
Just in case the bot has already commented on something.