### PR TITLE
ci(commenter): disable comments for now

### DIFF
--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -21,5 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FOSSIFYBOT_TOKEN }}
           label-template: "released"
           skip-label: "ci,dependencies,documentation,l10n,i18n,released"
-          comment-template: |
-            FYI: This is available in {release_link}. FossifyBot out.
+          comment-template: ""


### PR DESCRIPTION
#### Type of change(s)
- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Disabled release comments for now. Just until the number of things to comment on goes down.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).