### PR TITLE
ci(commenter): disable release commenter labelling

### DIFF
--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   releaseCommenter:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - id: app-token


### PR DESCRIPTION
#### Type of change(s)
- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Disabled release commenter labelling. It's inefficient, often hits rate limits, and is not useful with frequent releases.

It'll probably be removed permanently.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).