### PR TITLE
ci: add `testers needed` label to release PRs

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
+          labels: "testers needed"
           branch: fossifybot/release/v${{ steps.version-name.outputs.nextMajorStrict }}
           commit-message: "chore(release): v${{ steps.version-name.outputs.nextStrict }} (${{ steps.version-code.outputs.nextVersionCode }})"
           title: "chore(release): v${{ steps.version-name.outputs.nextStrict }} (${{ steps.version-code.outputs.nextVersionCode }})"


### PR DESCRIPTION
For automatically generating a build when a PR is created. This will work better when the release dispatcher is configured to run every 24 hrs for all repos. 