### PR TITLE
fix: cancel duplicate testing builds

### DIFF
--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -9,6 +9,10 @@ on:
         default: "testers needed"
         required: false
 
+concurrency:
+  group: testing-build-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use pull-request-scoped concurrency for the shared Testing Build workflow. This cancels older runs when opening and labeling trigger the same release PR, while preserving the existing trigger paths.

Validated with YAML parsing, structural checks, and the workflow event matrix.