### PR TITLE
ci: run contribution triage on .github repository

### DIFF
--- a/.github/workflows/image-minimizer.yml
+++ b/.github/workflows/image-minimizer.yml
@@ -2,6 +2,12 @@ name: Image Minimizer
 
 on:
   workflow_call:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+  pull_request_target:
+    types: [opened, edited]
 
 concurrency:
   group: image-minimizer-${{ github.event_name }}-${{ github.event.comment.id || github.event.issue.number || github.event.pull_request.number }}


### PR DESCRIPTION
Run the existing contribution-policy workflow for issues and pull requests opened in this repository. This adds the same event triggers used by the organization-wide caller template and leaves the policy implementation unchanged.

Follow-up to #225.