### PR TITLE
ci: include version code in release marker

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -78,7 +78,7 @@ echo "Creating release marker..."
 mkdir -p .fossify
 cat >.fossify/release-marker.txt <<EOF
 # Auto-generated file. DO NOT EDIT.
-$NEW_VERSION
+$NEW_VERSION ($VERSION_CODE)
 EOF
 
 echo "Version update completed successfully!"


### PR DESCRIPTION
#### Type of change(s)
- [x] Infrastructure / tooling (CI, build, deps, tests)

#### What changed and why
- Write release markers as `version (code)`, for example `1.11.0 (22)`.
- Reuse the `VERSION_CODE` argument already passed to the script; no workflow changes are needed.

#### Tests performed
- `bash -n scripts/update-version.sh`
- Ran the script in a disposable fixture with version `1.11.0` and code `22`; the marker contained `1.11.0 (22)` and the Gradle values were updated.

#### Checklist
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.